### PR TITLE
Switch to components registry for dynamic component

### DIFF
--- a/src/app/components/content-viewer/content-viewer.component.ts
+++ b/src/app/components/content-viewer/content-viewer.component.ts
@@ -4,7 +4,7 @@ import { AttributesMap } from 'ng-dynamic-component';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { filter, map, shareReplay } from 'rxjs/operators';
 import { GenericElementData } from 'src/app/models/parsed-elements';
-import { register } from '../../services/component-register.service';
+import { ComponentRegisterService, register } from '../../services/component-register.service';
 
 @Component({
   selector: 'evt-content-viewer',
@@ -22,8 +22,16 @@ export class ContentViewerComponent implements OnDestroy {
   contentChange = new BehaviorSubject<GenericElementData>(undefined);
   @ViewChild('container', { read: ViewContainerRef, static: false }) container: ViewContainerRef;
 
+  constructor(
+    private componentRegister: ComponentRegisterService,
+  ) {
+  }
   // tslint:disable-next-line: no-any
   public parsedContent: Observable<{ [keyName: string]: any }> = this.contentChange.pipe(
+    map((data) => ({
+      ...data,
+      type: this.componentRegister.getComponent(data.type),
+    })),
     shareReplay(1),
   );
 

--- a/src/app/models/parsed-elements.ts
+++ b/src/app/models/parsed-elements.ts
@@ -1,9 +1,7 @@
-import { Type } from '@angular/core';
 import { AttributesData, OriginalEncodingNodeType } from './evt-models';
 
 export interface GenericElementData {
-    // tslint:disable-next-line: no-any
-    type: Type<any>;
+    type: string;
     path?: string;
     class?: string;
     attributes: AttributesData;

--- a/src/app/services/xml-parsers/generic-parser.service.ts
+++ b/src/app/services/xml-parsers/generic-parser.service.ts
@@ -1,9 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
 import { map, scan } from 'rxjs/operators';
-import { GenericElementComponent } from '../../components/generic-element/generic-element.component';
-import { NoteComponent } from '../../components/note/note.component';
-import { TextComponent } from '../../components/text/text.component';
 import { AttributesData, NamedEntitiesList, XMLElement } from '../../models/evt-models';
 import { CommentData, GenericElementData, HTMLData, NoteData, TextData } from '../../models/parsed-elements';
 import { isNestedInElem, xpath } from '../../utils/dom-utils';
@@ -46,7 +43,7 @@ export class GenericParserService {
 
   private parseText(xml: XMLElement): TextData {
     const text = {
-      type: TextComponent,
+      type: 'TextComponent',
       text: replaceMultispaces(xml.textContent),
       attributes: {},
     } as TextData;
@@ -56,7 +53,7 @@ export class GenericParserService {
 
   private parseElement(xml: XMLElement): GenericElementData {
     const genericElement: GenericElementData = {
-      type: GenericElementComponent,
+      type: 'GenericElementComponent',
       class: xml.tagName ? xml.tagName.toLowerCase() : '',
       content: this.parseChildren(xml),
       attributes: this.parseAttributes(xml),
@@ -73,7 +70,7 @@ export class GenericParserService {
       return this.parseElement(xml);
     }
     const noteElement = {
-      type: NoteComponent,
+      type: 'NoteComponent',
       path: xpath(xml),
       content: this.parseChildren(xml),
       attributes: this.parseAttributes(xml),

--- a/src/app/services/xml-parsers/named-entities-parser.service.ts
+++ b/src/app/services/xml-parsers/named-entities-parser.service.ts
@@ -3,9 +3,6 @@ import { AttributesMap } from 'ng-dynamic-component';
 import { combineLatest, Observable } from 'rxjs';
 import { map, shareReplay } from 'rxjs/operators';
 import { AppConfig } from '../../app.config';
-import { GenericElementComponent } from '../../components/generic-element/generic-element.component';
-import { NamedEntityDetailComponent } from '../../components/named-entity/named-entity-detail/named-entity-detail.component';
-import { NamedEntityComponent } from '../../components/named-entity/named-entity.component';
 import {
   Description, NamedEntities, NamedEntitiesList, NamedEntity, NamedEntityInfo,
   NamedEntityLabel, NamedEntityType, Relation, XMLElement,
@@ -92,7 +89,7 @@ export class NamedEntitiesParserService {
 
   private parseList(list: XMLElement) {
     const parsedList: NamedEntitiesList = {
-      type: GenericElementComponent, // TODO: Set NamedEntitiesListComponent
+      type: 'GenericElementComponent', // TODO: Set NamedEntitiesListComponent
       id: list.getAttribute('xml:id') || xpath(list),
       label: '',
       namedEntityType: this.getListType(list.tagName),
@@ -158,7 +155,7 @@ export class NamedEntitiesParserService {
     const elId = xml.getAttribute('xml:id') || xpath(xml);
     const label = replaceNewLines(xml.textContent) || 'No info';
     const entity: NamedEntity = {
-      type: NamedEntityComponent,
+      type: 'NamedEntityComponent',
       id: elId,
       sortKey: xml.getAttribute('sortKey') || (label ? label[0] : '') || xml.getAttribute('xml:id') || xpath(xml),
       originalEncoding: xml,
@@ -275,7 +272,7 @@ export class NamedEntitiesParserService {
 
   private parseEntityInfo(xml: XMLElement): NamedEntityInfo {
     return {
-      type: NamedEntityDetailComponent,
+      type: 'NamedEntityDetailComponent',
       label: xml.nodeType === 1 ? xml.tagName.toLowerCase() : 'info',
       content: [this.genericParserService.parse(xml)],
       attributes: xml.nodeType === 1 ? this.parseAttributes(xml) : {},


### PR DESCRIPTION
Change parsing output to use component registry in content viewer component, in order to avoid too many dependencies in parsing services.