### PR TITLE
Feature/named entities occurrences

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { GlobalListsComponent } from './components/global-lists/global-lists.com
 import { NamedEntitiesListComponent } from './components/named-entities-list/named-entities-list.component';
 import { NamedEntityRefComponent } from './components/named-entity-ref/named-entity-ref.component';
 import { NamedEntityDetailComponent } from './components/named-entity/named-entity-detail/named-entity-detail.component';
+import { NamedEntityOccurrenceComponent } from './components/named-entity/named-entity-occurrence/named-entity-occurrence.component';
 import { NamedEntityComponent } from './components/named-entity/named-entity.component';
 import { NoteComponent } from './components/note/note.component';
 import { OriginalEncodingViewerComponent } from './components/original-encoding-viewer/original-encoding-viewer.component';
@@ -79,6 +80,7 @@ export function initializeApp(appConfig: AppConfig) {
     NamedEntitiesListComponent,
     NamedEntityComponent,
     NamedEntityDetailComponent,
+    NamedEntityOccurrenceComponent,
     NamedEntityRefComponent,
     NoteComponent,
     OriginalEncodingViewerComponent,

--- a/src/app/components/named-entity/named-entity-occurrence/named-entity-occurrence.component.html
+++ b/src/app/components/named-entity/named-entity-occurrence/named-entity-occurrence.component.html
@@ -1,0 +1,17 @@
+<span class="ne-occurrence" *ngFor="let refByDoc of occurrence.refsByDoc">
+    {{ occurrence.pageLabel }} {{ refByDoc.docLabel ? '(' + refByDoc.docLabel + ')' : '' }}
+    <span class="badge badge-info badge-light ne-occurrence-count"
+        #popover="ngbPopover" 
+        [ngbPopover]="popContent" 
+        [autoClose]="'outside'" 
+        popoverClass="evt-note"
+        container="body" 
+        [placement]="['auto']">
+        {{refByDoc.refs?.length}}
+    </span>
+    <ng-template #popContent>
+        <div *ngFor="let ref of refByDoc.refs">
+            <evt-content-viewer [content]="ref"></evt-content-viewer>
+        </div>
+    </ng-template>
+</span>

--- a/src/app/components/named-entity/named-entity-occurrence/named-entity-occurrence.component.spec.ts
+++ b/src/app/components/named-entity/named-entity-occurrence/named-entity-occurrence.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NamedEntityOccurrenceComponent } from './named-entity-occurrence.component';
+
+describe('NamedEntityOccurrenceComponent', () => {
+  let component: NamedEntityOccurrenceComponent;
+  let fixture: ComponentFixture<NamedEntityOccurrenceComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NamedEntityOccurrenceComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NamedEntityOccurrenceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/named-entity/named-entity-occurrence/named-entity-occurrence.component.ts
+++ b/src/app/components/named-entity/named-entity-occurrence/named-entity-occurrence.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+import { NamedEntityOccurrence } from 'src/app/models/evt-models';
+
+@Component({
+  selector: 'evt-named-entity-occurrence',
+  templateUrl: './named-entity-occurrence.component.html',
+  styleUrls: ['./named-entity-occurrence.component.scss'],
+})
+export class NamedEntityOccurrenceComponent {
+  @Input() occurrence: NamedEntityOccurrence;
+}

--- a/src/app/components/named-entity/named-entity.component.html
+++ b/src/app/components/named-entity/named-entity.component.html
@@ -30,18 +30,8 @@
             <ngb-tab [title]="'Occurrences' | translate">
                 <ng-template ngbTabContent>
                     <div class="ne-tab-content" *ngIf="data.occurrences$ | async as occurrences">
-                        <ng-container *ngFor="let occurrence of occurrences">
-                            <span class="ne-occurrence" *ngFor="let refByDoc of occurrence.refsByDoc">
-                                    {{ occurrence.pageLabel }} {{ refByDoc.docLabel ? '(' + refByDoc.docLabel + ')' : '' }}
-                                <span #popover="ngbPopover" [ngbPopover]="popContent"
-                                [autoClose]="'outside'" popoverClass="evt-note" container="body" [placement]="['auto']" class="badge badge-info badge-light ne-occurrence-count">
-                                    {{refByDoc.refs?.length}}</span>
-                                <ng-template #popContent>
-                                    <div *ngFor="let ref of refByDoc.refs"><evt-content-viewer [content]="ref"></evt-content-viewer></div>
-                                </ng-template>
-                            </span>
-                        </ng-container>
                         <span *ngIf="occurrences.length === 0">{{'noOccurrences' | translate}}</span>
+                        <evt-named-entity-occurrence *ngFor="let occurrence of occurrences" [occurrence]="occurrence"></evt-named-entity-occurrence>
                     </div>
                 </ng-template>
             </ngb-tab>

--- a/src/app/components/named-entity/named-entity.component.html
+++ b/src/app/components/named-entity/named-entity.component.html
@@ -49,13 +49,6 @@
                     </div>
                 </ng-template>
             </ngb-tab>
-            <ngb-tab title="EVT JSON Model">
-                <ng-template ngbTabContent>
-                    <div class="ne-tab-content no-padding">
-                        <pre>{{ data | json }}</pre>
-                    </div>
-                </ng-template>
-            </ngb-tab>
         </ngb-tabset>
     </div>
 </div>

--- a/src/app/components/named-entity/named-entity.component.html
+++ b/src/app/components/named-entity/named-entity.component.html
@@ -31,7 +31,11 @@
                 <ng-template ngbTabContent>
                     <div class="ne-tab-content" *ngIf="data.occurrences$ | async as occurrences">
                         <span class="ne-occurrence" *ngFor="let occurrence of occurrences">{{ occurrence.pageLabel }} 
-                            <span class="badge badge-info badge-light ne-occurrence-count">{{occurrence.count}}</span>
+                            <span #popover="ngbPopover" [ngbPopover]="popContent"
+                            [autoClose]="'outside'" popoverClass="evt-note" container="body" [placement]="['auto']" class="badge badge-info badge-light ne-occurrence-count">{{occurrence.refs?.length}}</span>
+                            <ng-template #popContent>
+                                <div *ngFor="let ref of occurrence.refs"><evt-content-viewer [content]="ref"></evt-content-viewer></div>
+                            </ng-template>
                         </span>
                         <span *ngIf="occurrences.length === 0">{{'noOccurrences' | translate}}</span>
                     </div>

--- a/src/app/components/named-entity/named-entity.component.html
+++ b/src/app/components/named-entity/named-entity.component.html
@@ -29,9 +29,11 @@
             </ngb-tab>
             <ngb-tab [title]="'Occurrences' | translate">
                 <ng-template ngbTabContent>
-                    <div class="ne-tab-content">
-                        <span *ngFor="let occurrence of data.occurrences"> {{ occurrence }} </span>
-                        <span *ngIf="data.occurrences.length === 0">{{'NoOccurrences' | translate}}</span>
+                    <div class="ne-tab-content" *ngIf="data.occurrences$ | async as occurrences">
+                        <span class="ne-occurrence" *ngFor="let occurrence of occurrences">{{ occurrence.pageLabel }} 
+                            <span class="badge badge-info badge-light ne-occurrence-count">{{occurrence.count}}</span>
+                        </span>
+                        <span *ngIf="occurrences.length === 0">{{'noOccurrences' | translate}}</span>
                     </div>
                 </ng-template>
             </ngb-tab>

--- a/src/app/components/named-entity/named-entity.component.html
+++ b/src/app/components/named-entity/named-entity.component.html
@@ -30,13 +30,17 @@
             <ngb-tab [title]="'Occurrences' | translate">
                 <ng-template ngbTabContent>
                     <div class="ne-tab-content" *ngIf="data.occurrences$ | async as occurrences">
-                        <span class="ne-occurrence" *ngFor="let occurrence of occurrences">{{ occurrence.pageLabel }} 
-                            <span #popover="ngbPopover" [ngbPopover]="popContent"
-                            [autoClose]="'outside'" popoverClass="evt-note" container="body" [placement]="['auto']" class="badge badge-info badge-light ne-occurrence-count">{{occurrence.refs?.length}}</span>
-                            <ng-template #popContent>
-                                <div *ngFor="let ref of occurrence.refs"><evt-content-viewer [content]="ref"></evt-content-viewer></div>
-                            </ng-template>
-                        </span>
+                        <ng-container *ngFor="let occurrence of occurrences">
+                            <span class="ne-occurrence" *ngFor="let refByDoc of occurrence.refsByDoc">
+                                    {{ occurrence.pageLabel }} {{ refByDoc.docLabel ? '(' + refByDoc.docLabel + ')' : '' }}
+                                <span #popover="ngbPopover" [ngbPopover]="popContent"
+                                [autoClose]="'outside'" popoverClass="evt-note" container="body" [placement]="['auto']" class="badge badge-info badge-light ne-occurrence-count">
+                                    {{refByDoc.refs?.length}}</span>
+                                <ng-template #popContent>
+                                    <div *ngFor="let ref of refByDoc.refs"><evt-content-viewer [content]="ref"></evt-content-viewer></div>
+                                </ng-template>
+                            </span>
+                        </ng-container>
                         <span *ngIf="occurrences.length === 0">{{'noOccurrences' | translate}}</span>
                     </div>
                 </ng-template>

--- a/src/app/components/named-entity/named-entity.component.scss
+++ b/src/app/components/named-entity/named-entity.component.scss
@@ -44,6 +44,33 @@
   .ne-tab-content {
     background-color: $color-darker;
   }
+
+  .ne-occurrence {
+    border-radius: 4px;
+    padding: 4px 6px;
+    background: rgba(255, 255, 255, 0.5);
+    margin-right: 3px;
+    font-size: .7rem;
+    margin-bottom: 3px;
+    display: inline-block !important;
+    cursor: pointer;
+    line-height: 0.9rem;
+
+    .ne-occurrence-count {
+      top: -1px;
+      position: relative;
+      margin-left: 5px;
+      border: 1px solid transparent;
+    }
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.8) !important;
+      .ne-occurrence-count {
+        border: 1px solid #ccc;
+      }
+    }
+
+  }
 }
 
 :host ::ng-deep .ne {

--- a/src/app/models/evt-models.ts
+++ b/src/app/models/evt-models.ts
@@ -1,3 +1,4 @@
+import { Observable } from 'rxjs';
 import { Map } from '../utils/js-utils';
 import { GenericElementData } from './parsed-elements';
 
@@ -66,7 +67,7 @@ export interface NamedEntity extends GenericElementData {
     label: NamedEntityLabel;
     namedEntityType: NamedEntityType | 'personGrp';
     content: NamedEntityInfo[];
-    occurrences: string[]; // TODO: evaluate which type assign
+    occurrences$: Observable<NamedEntityOccurrence[]>;
     originalEncoding: OriginalEncodingNodeType;
 }
 

--- a/src/app/models/evt-models.ts
+++ b/src/app/models/evt-models.ts
@@ -81,7 +81,7 @@ export interface NamedEntityInfo extends GenericElementData {
 export interface NamedEntityOccurrence {
     pageId: string;
     pageLabel: string;
-    count: number;
+    refs: GenericElementData[];
 }
 
 export type Relation = OriginalEncodingData & {

--- a/src/app/models/evt-models.ts
+++ b/src/app/models/evt-models.ts
@@ -77,6 +77,12 @@ export interface NamedEntityInfo extends GenericElementData {
     content: Array<GenericElementData | NamedEntitiesList>;
 }
 
+export interface NamedEntityOccurrence {
+    pageId: string;
+    pageLabel: string;
+    count: number;
+}
+
 export type Relation = OriginalEncodingData & {
     name?: string;
     activeParts: string[]; // Pointers to entities involved in relation

--- a/src/app/models/evt-models.ts
+++ b/src/app/models/evt-models.ts
@@ -81,6 +81,11 @@ export interface NamedEntityInfo extends GenericElementData {
 export interface NamedEntityOccurrence {
     pageId: string;
     pageLabel: string;
+    refsByDoc: NamedEntityOccurrenceRef[];
+}
+export interface NamedEntityOccurrenceRef {
+    docId: string;
+    docLabel: string;
     refs: GenericElementData[];
 }
 

--- a/src/app/services/xml-parsers/generic-parser.service.ts
+++ b/src/app/services/xml-parsers/generic-parser.service.ts
@@ -57,7 +57,7 @@ export class GenericParserService {
     return text;
   }
 
-  private parseElement(xml: XMLElement): GenericElementData {
+  public parseElement(xml: XMLElement): GenericElementData {
     const genericElement: GenericElementData = {
       type: 'GenericElementComponent',
       class: xml.tagName ? xml.tagName.toLowerCase() : '',

--- a/src/app/services/xml-parsers/named-entities-parser.service.ts
+++ b/src/app/services/xml-parsers/named-entities-parser.service.ts
@@ -64,7 +64,7 @@ export class NamedEntitiesParserService {
     shareReplay(1),
   );
 
-  public occurrences$: Observable<Map<NamedEntityOccurrence>> = this.evtModelService.getPages().pipe(
+  public occurrences$: Observable<Map<NamedEntityOccurrence[]>> = this.evtModelService.getPages().pipe(
     map((pages) => pages.map(p => {
       return p.originalContent
         .filter(e => e.nodeType === 1)
@@ -201,7 +201,10 @@ export class NamedEntitiesParserService {
       namedEntityType: this.getEntityType(xml.tagName),
       content: Array.from(xml.children).map((subchild: XMLElement) => this.parseEntityInfo(subchild)),
       attributes: this.parseAttributes(xml),
-      occurrences: [],
+      occurrences$: this.occurrences$.pipe(
+        map(occ => occ[elId] || []),
+        shareReplay(1),
+      ),
     };
 
     return entity;

--- a/src/app/services/xml-parsers/named-entities-parser.service.ts
+++ b/src/app/services/xml-parsers/named-entities-parser.service.ts
@@ -68,15 +68,18 @@ export class NamedEntitiesParserService {
     map((pages) => pages.map(p => {
       return p.originalContent
         .filter(e => e.nodeType === 1)
-        .map(e => Array.from(e.querySelectorAll(this.tagNamesMap.occurrences))
-          .map(al => al.getAttribute('ref').replace('#', '')))
+        .map(e => Array.from(e.querySelectorAll<XMLElement>(this.tagNamesMap.occurrences))
+          .map(el => ({
+            ref: el.getAttribute('ref').replace('#', ''),
+            el: this.genericParserService.parse(el),
+          })))
         .filter(e => e.length > 0)
         .reduce((x, y) => x.concat(y), [])
         .reduce((x, y) => ({
-          ...x, [y]: {
+          ...x, [y.ref]: {
             pageId: p.id,
             pageLabel: p.label,
-            count: x[y] && x[y].count ? x[y].count + 1 : 1,
+            refs: x[y.ref] && x[y.ref].refs ? x[y.ref].refs.concat([y.el]) : [y.el],
           } as NamedEntityOccurrence,
         }),     {});
     })),

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -24,5 +24,6 @@
     "noEntities": "No entities in this list",
     "search": "Search",
     "noMatches": "No matches for input given",
-    "entityNotFound": "Entity not found"
+    "entityNotFound": "Entity not found",
+    "noOccurrences": "No occurrences"
 }

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -23,5 +23,6 @@
     "noEntities": "Nessuna entità in questa lista",
     "search": "Cerca",
     "noMatches": "Nessun risultato",
-    "entityNotFound": "Entità non trovata"
+    "entityNotFound": "Entità non trovata",
+    "noOccurrences": "Nessuna occorrenza"
 }


### PR DESCRIPTION
I've added the parser to extract NE occurrences based on page list. 
Since everything depends on the page (at least for now), I think this can work. 
I've also handled cases like [Codice Pelavicino](https://pelavicino.labcd.unipi.it/evt) where there could be multiple documents in a single page, and references can be in the same page but belong to different documents.

Navigation to the occurrence page has not been handled in this PR, since navigation is not properly implemented yet.