### PR TITLE
Move `entitiesSelectItems` param from UiConfig to EditionConfig

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -62,7 +62,6 @@ export interface UiConfig {
         label: string;
         enabled: boolean;
     }>;
-    entitiesSelectItems: EntitiesSelectItemGroup[];
 }
 
 export interface EditionConfig {
@@ -77,6 +76,7 @@ export interface EditionConfig {
         relations: NamedEntitiesListsConfig;
         events: NamedEntitiesListsConfig;
     }>;
+    entitiesSelectItems: EntitiesSelectItemGroup[];
 }
 
 export interface FileConfig {

--- a/src/app/components/entities-select/entities-select.component.ts
+++ b/src/app/components/entities-select/entities-select.component.ts
@@ -22,7 +22,7 @@ export interface EntitiesSelectItem {
 export class EntitiesSelectComponent {
   @Output() selectionChange: EventEmitter<EntitiesSelectItem[]> = new EventEmitter();
 
-  entitiesTypes: Array<EntitiesSelectItem & { group: string }> = (AppConfig.evtSettings.ui.entitiesSelectItems || [])
+  entitiesTypes: Array<EntitiesSelectItem & { group: string }> = (AppConfig.evtSettings.edition.entitiesSelectItems || [])
     .filter(g => !g.disabled)
     .reduce((x, y) => [...x, ...y.items.filter(i => !i.disabled).map(i => ({ ...i, group: y.label }))], []);
 

--- a/src/app/services/entities-select.service.ts
+++ b/src/app/services/entities-select.service.ts
@@ -37,7 +37,7 @@ export class EntitiesSelectService {
   }
 
   public getHighlightColor(attributesToCheck: AttributesData, classNameToCheck: string, selectedItems?: EntitiesSelectItem[]) {
-    const entitiesSelectItems = AppConfig.evtSettings.ui.entitiesSelectItems
+    const entitiesSelectItems = AppConfig.evtSettings.edition.entitiesSelectItems
       .reduce((i: EntitiesSelectItem[], g) => i.concat(g.items), [])
       .reduce((x: EntitiesSelectItem[], y) => {
         const multiValues: EntitiesSelectItem[] = [];

--- a/src/assets/config/edition_config.json
+++ b/src/assets/config/edition_config.json
@@ -33,5 +33,49 @@
 			"defaultLabel": "Events",
 			"enabled": true
 		}
-	}
+	},
+	"entitiesSelectItems": [
+		{
+			"label": "Named Entities",
+			"items": [
+				{
+					"value": "persName",
+					"label": "persons",
+					"color": "#ffcdd2"
+				},
+				{
+					"value": "persName[type='episcopus']",
+					"label": "bishops",
+					"color": "rgb(139, 98, 236)"
+				},
+				{
+					"value": "placeName,geogName",
+					"label": "places",
+					"color": "#A5D6A7"
+				},
+				{
+					"value": "orgName",
+					"label": "organizations",
+					"color": "#FFB74D"
+				}
+			]
+		}, {
+			"label": "Other",
+			"items": [
+				{
+					"value": "event",
+					"label": "events",
+					"color": "#fcfc60"
+				},
+				{
+					"value": "rolename",
+					"label": "roles"
+				},
+				{
+					"value": "measure",
+					"label": "measures"
+				}
+			]
+		}
+	]
 }

--- a/src/assets/config/ui_config.json
+++ b/src/assets/config/ui_config.json
@@ -12,49 +12,5 @@
 			"label": "languageIt",
 			"enabled": true
 		}
-	],
-	"entitiesSelectItems": [
-		{
-			"label": "Named Entities",
-			"items": [
-				{
-					"value": "persName",
-					"label": "persons",
-					"color": "#ffcdd2"
-				},
-				{
-					"value": "persName[type='episcopus']",
-					"label": "bishops",
-					"color": "rgb(139, 98, 236)"
-				},
-				{
-					"value": "placeName,geogName",
-					"label": "places",
-					"color": "#A5D6A7"
-				},
-				{
-					"value": "orgName",
-					"label": "organizations",
-					"color": "#FFB74D"
-				}
-			]
-		}, {
-			"label": "Other",
-			"items": [
-				{
-					"value": "event",
-					"label": "events",
-					"color": "#fcfc60"
-				},
-				{
-					"value": "rolename",
-					"label": "roles"
-				},
-				{
-					"value": "measure",
-					"label": "measures"
-				}
-			]
-		}
 	]
 }


### PR DESCRIPTION
Even if it allows to define elements and colors to populate a selector and highlight items, this parameter is more connected to the edition content than to the generic UI. That's why I propose this modification.