### PR TITLE
Change necessary parsers startup logic and move data to EVTModelService

### DIFF
--- a/src/app/components/global-lists/global-lists.component.ts
+++ b/src/app/components/global-lists/global-lists.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
-import { Map } from 'src/app/utils/js-utils';
+
 import { NamedEntitiesList, Relation } from '../../models/evt-models';
-import { NamedEntitiesParserService } from '../../services/xml-parsers/named-entities-parser.service';
+import { EVTModelService } from '../../services/evt-model.service';
+import { Map } from '../../utils/js-utils';
 
 interface GlobalList extends NamedEntitiesList {
   icon: string;
@@ -15,7 +16,7 @@ interface GlobalList extends NamedEntitiesList {
   styleUrls: ['./global-lists.component.scss'],
 })
 export class GlobalListsComponent {
-  lists$: Observable<GlobalList[]> = this.neParserService.namedEntities$.pipe(
+  lists$: Observable<GlobalList[]> = this.evtModelService.namedEntities$.pipe(
     map(ne => (ne.persons.lists.concat(ne.places.lists, ne.organizations.lists, ne.events.lists))),
     map(lists => (lists.map(list => ({
       ...list,
@@ -29,7 +30,7 @@ export class GlobalListsComponent {
   );
   selectedList: NamedEntitiesList;
 
-  relations$: Observable<Relation[]> = this.neParserService.namedEntities$.pipe(
+  relations$: Observable<Relation[]> = this.evtModelService.namedEntities$.pipe(
     map(ne => ne.relations),
   );
 
@@ -43,7 +44,7 @@ export class GlobalListsComponent {
   };
 
   constructor(
-    private neParserService: NamedEntitiesParserService,
+    private evtModelService: EVTModelService,
   ) {
   }
 

--- a/src/app/components/named-entity-ref/named-entity-ref.component.ts
+++ b/src/app/components/named-entity-ref/named-entity-ref.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input } from '@angular/core';
 import { map, tap } from 'rxjs/operators';
+
 import { HighlightableComponent } from '../../highlightable/highlightable.component';
 import { NamedEntityRefData } from '../../models/evt-models';
 import { register } from '../../services/component-register.service';
 import { EntitiesSelectService } from '../../services/entities-select.service';
-import { NamedEntitiesParserService } from '../../services/xml-parsers/named-entities-parser.service';
+import { EVTModelService } from '../../services/evt-model.service';
 
 @Component({
   selector: 'evt-named-entity-ref',
@@ -15,7 +16,7 @@ import { NamedEntitiesParserService } from '../../services/xml-parsers/named-ent
 export class NamedEntityRefComponent extends HighlightableComponent {
   @Input() data: NamedEntityRefData;
 
-  entity$ = this.neParserService.namedEntities$.pipe(
+  entity$ = this.evtModelService.namedEntities$.pipe(
     map(ne => ne.all.entities.find(e => e.id === this.data.entityId) || 'notFound'),
   );
 
@@ -35,7 +36,7 @@ export class NamedEntityRefComponent extends HighlightableComponent {
   public opened = false;
 
   constructor(
-    private neParserService: NamedEntitiesParserService,
+    private evtModelService: EVTModelService,
     private entitiesSelectService: EntitiesSelectService,
   ) {
     super();

--- a/src/app/components/named-entity-relation/named-entity-relation.component.ts
+++ b/src/app/components/named-entity-relation/named-entity-relation.component.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { NamedEntity, Relation } from '../../models/evt-models';
 import { register } from '../../services/component-register.service';
-import { NamedEntitiesParserService } from '../../services/xml-parsers/named-entities-parser.service';
+import { EVTModelService } from '../../services/evt-model.service';
 
 @register
 @Component({
@@ -22,7 +22,7 @@ export class NamedEntityRelationComponent {
   passiveParts$ = this.getEntities('passiveParts');
 
   constructor(
-    private neParserService: NamedEntitiesParserService,
+    private evtModelService: EVTModelService,
   ) {
   }
 
@@ -39,7 +39,7 @@ export class NamedEntityRelationComponent {
 
   private getEntities(partIdsGroup: 'activeParts' | 'mutualParts' | 'passiveParts'):
     Observable<Array<{ id: string; entity: NamedEntity; label: string }>> {
-    return this.neParserService.namedEntities$.pipe(
+    return this.evtModelService.namedEntities$.pipe(
       map(ne => this.data[partIdsGroup].map(entityId => {
         const entity = ne.all.entities.find(e => e.id === entityId);
 

--- a/src/app/models/evt-models.ts
+++ b/src/app/models/evt-models.ts
@@ -17,6 +17,11 @@ export interface PageData {
     parsedContent: GenericElementData[];
 }
 
+export interface NamedEntitiesListData {
+    lists: NamedEntitiesList[];
+    entities: NamedEntity[];
+}
+
 export interface NamedEntities {
     all: {
         lists: NamedEntitiesList[];

--- a/src/app/services/edition-data.service.ts
+++ b/src/app/services/edition-data.service.ts
@@ -1,10 +1,12 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { catchError, map, publishReplay, refCount } from 'rxjs/operators';
+import { catchError, map, publishReplay, refCount, tap } from 'rxjs/operators';
 import { AppConfig } from '../app.config';
 import { OriginalEncodingNodeType, XMLElement } from '../models/evt-models';
 import { parseXml } from '../utils/xml-utils';
+import { NamedEntitiesParserService } from './xml-parsers/named-entities-parser.service';
+import { StructureXmlParserService } from './xml-parsers/structure-xml-parser.service';
 
 @Injectable({
   providedIn: 'root',
@@ -15,6 +17,8 @@ export class EditionDataService {
 
   constructor(
     private http: HttpClient,
+    private structureParser: StructureXmlParserService,
+    private neParserService: NamedEntitiesParserService,
   ) {
   }
 
@@ -29,6 +33,10 @@ export class EditionDataService {
         }
 
         return editionDoc;
+      }),
+      tap(source => {
+        this.structureParser.parsePages(source);
+        this.neParserService.parseLists(source);
       }),
       publishReplay(1),
       refCount(),

--- a/src/app/services/xml-parsers/structure-xml-parser.service.ts
+++ b/src/app/services/xml-parsers/structure-xml-parser.service.ts
@@ -1,35 +1,22 @@
 import { Injectable } from '@angular/core';
-import { map, shareReplay } from 'rxjs/operators';
 
 import { PageData, XMLElement } from '../../models/evt-models';
 import { getElementsAfterTreeNode, getElementsBetweenTreeNode } from '../../utils/dom-utils';
 import { Map } from '../../utils/js-utils';
-import { EditionDataService } from '../edition-data.service';
+import { EVTModelService } from '../evt-model.service';
 import { GenericParserService } from './generic-parser.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class StructureXmlParserService {
-  public readonly editionStructure$ = this.editionDataService.parsedEditionSource$
-    .pipe(
-      map((source) => this.init(source)),
-      shareReplay(1),
-    );
-
   constructor(
-    private editionDataService: EditionDataService,
+    private evtModelService: EVTModelService,
     private genericParserService: GenericParserService,
   ) {
-
   }
 
-  getPages() {
-    return this.editionStructure$.pipe(
-      map(editionStructure => editionStructure.pagesIndexes.map(pageId => editionStructure.pages[pageId])));
-  }
-
-  init(document: XMLElement) {
+  parsePages(document: XMLElement) {
     const pages: Map<PageData> = {};
     const pagesIndexes: string[] = [];
     const pageTagName = 'pb';
@@ -72,6 +59,8 @@ export class StructureXmlParserService {
       }
       console.log(pages);
     }
+
+    this.evtModelService.pages$.next(pagesIndexes.map(pageId => pages[pageId]));
 
     return {
       pages,


### PR DESCRIPTION
I have moved the results of the parsers of the edition data in the EVTModelService. This service is designed to not inject any other service that manages data parsing; the latter will update data in EVTModelService. This was done to avoid unpleasant circular dependencies if the components of the textual content need to access the data during parsing (e.g. in NamedEntitiyRefComponent). As a consequence of this change it was necessary to add an explicit launch of the parsers following the reading of the edition source file.