### PR TITLE
Feature/missing and disabled named entities

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -68,6 +68,7 @@ export interface EditionConfig {
     editionTitle: string;
     badge: string;
     editionHome: string;
+    showLists: boolean;
     availableEditionLevels: EditionLevel[];
     namedEntitiesLists: Partial<{
         persons: NamedEntitiesListsConfig;

--- a/src/app/components/named-entity-ref/named-entity-ref.component.html
+++ b/src/app/components/named-entity-ref/named-entity-ref.component.html
@@ -1,13 +1,16 @@
 <span class="namedEntityRef {{ data.entityType }}" (click)="toggleEntityData($event)" [ngClass]="{
-        opened: opened
+        opened: opened,
+        noDetails: !(availableEntities$ | async)
     }"
 	[class.highlight]="highlightData?.highlight" [style.background]="highlightData && highlightData.highlight ? highlightData.highlightColor : ''">
     <evt-content-viewer *ngFor="let element of data.content" [content]="element" [itemsToHighlight]="itemsToHighlight"></evt-content-viewer>
 </span>
-<div *ngIf="opened" class="namedEntityRefDetail {{ data.entityType }}">
-    <ng-container *ngIf="entity$ | async as entity; else loading">
-        <span *ngIf="entity === 'notFound'" class="d-block p-2 pl-3 font-italic font-weight-light not-found-msg">{{ 'entityNotFound' | translate }}</span>
-        <evt-named-entity *ngIf="entity !== 'notFound'" [inList]="true" [data]="entity"> </evt-named-entity>
-    </ng-container>
-    <ng-template #loading>Loading...</ng-template>
-</div>
+<ng-container *ngIf="availableEntities$ | async">
+    <div *ngIf="opened" class="namedEntityRefDetail {{ data.entityType }}">
+        <ng-container *ngIf="entity$ | async as entity; else loading">
+            <span *ngIf="entity === 'notFound'" class="d-block p-2 pl-3 font-italic font-weight-light not-found-msg">{{ 'entityNotFound' | translate }}</span>
+            <evt-named-entity *ngIf="entity !== 'notFound'" [inList]="true" [data]="entity"> </evt-named-entity>
+        </ng-container>
+        <ng-template #loading>Loading...</ng-template>
+    </div>
+</ng-container>

--- a/src/app/components/named-entity-ref/named-entity-ref.component.scss
+++ b/src/app/components/named-entity-ref/named-entity-ref.component.scss
@@ -2,18 +2,20 @@
 @import "../../../assets/scss/mixins";
 
 .namedEntityRef {
-  cursor: pointer;
-  &.opened {
-    border-bottom: 3px solid;
+  &:not(.noDetails) {
+    cursor: pointer;
+    &.opened {
+      border-bottom: 3px solid;
+    }
   }
   &:not(.opened):not(:hover) {
     background-color: transparent;
   }
 }
 
-.namedEntityRef:hover,
+.namedEntityRef:hover:not(.noDetails),
 .namedEntityRef.highlighted,
-.namedEntityRef.opened {
+.namedEntityRef.opened:not(.noDetails) {
   &.person {
     @include namedEntityRefColors(get-ne-color(personBase), get-ne-color(personMiddle), get-ne-color(personDarker));
   }
@@ -42,7 +44,6 @@
     background: get-ne-color(eventBase);
   }
 }
-
 .not-found-msg {
   font-size: .9rem;
 }

--- a/src/app/components/named-entity-ref/named-entity-ref.component.ts
+++ b/src/app/components/named-entity-ref/named-entity-ref.component.ts
@@ -14,7 +14,9 @@ import { EVTModelService } from '../../services/evt-model.service';
 @register(NamedEntityRefData)
 export class NamedEntityRefComponent extends HighlightableComponent {
   @Input() data: NamedEntityRefData;
-
+  availableEntities$ = this.evtModelService.namedEntities$.pipe(
+    map(ne => ne.all.entities.length > 0),
+  );
   entity$ = this.evtModelService.namedEntities$.pipe(
     map(ne => ne.all.entities.find(e => e.id === this.data.entityId) || 'notFound'),
   );

--- a/src/app/main-menu/main-menu.component.html
+++ b/src/app/main-menu/main-menu.component.html
@@ -1,10 +1,12 @@
 <div class="mainMenu" (clickOutside)="closeMenu()" (escape)="closeMenu()">
     <ul>
-        <li *ngFor="let item of dynamicItems; trackBy: trackMenuItem">
-            <span (click)="item.callback()">
-                <evt-icon [iconInfo]="item.iconInfo"></evt-icon>{{item.label | translate}}
-            </span>
-        </li>
+        <ng-container *ngFor="let item of dynamicItems; trackBy: trackMenuItem">
+            <li *ngIf="item.enabled$ | async">
+                <span (click)="item.callback()">
+                    <evt-icon [iconInfo]="item.iconInfo"></evt-icon>{{item.label | translate}}
+                </span>
+            </li>
+        </ng-container>
     </ul>
     <hr />
     <ul>

--- a/src/app/main-menu/main-menu.component.ts
+++ b/src/app/main-menu/main-menu.component.ts
@@ -2,7 +2,7 @@
 import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
-import { AppConfig, FileConfig, UiConfig } from '../app.config';
+import { AppConfig } from '../app.config';
 import { GlobalListsComponent } from '../components/global-lists/global-lists.component';
 import { EvtInfoComponent } from '../evt-info/evt-info.component';
 import { ColorTheme, ThemesService } from '../services/themes.service';
@@ -19,8 +19,9 @@ import { ModalService } from '../ui-components/modal/modal.service';
 export class MainMenuComponent implements OnInit, OnDestroy {
   @Output() itemClicked = new EventEmitter<string>();
   public dynamicItems: MainMenuItem[] = [];
-  public uiConfig: UiConfig = AppConfig.evtSettings.ui;
-  public fileConfig: FileConfig = AppConfig.evtSettings.files;
+  public uiConfig = AppConfig.evtSettings.ui;
+  public fileConfig = AppConfig.evtSettings.files;
+  public editionConfig = AppConfig.evtSettings.edition;
 
   private isOpened = false;
   private subscriptions = [];
@@ -59,7 +60,7 @@ export class MainMenuComponent implements OnInit, OnDestroy {
           additionalClasses: 'icon',
         },
         label: 'projectInfo',
-        // callback: () => this.openGlobalDialogInfo,
+        enabled$: of(true),
         callback: () => this.openGlobalDialogInfo(),
       },
       {
@@ -69,6 +70,7 @@ export class MainMenuComponent implements OnInit, OnDestroy {
           additionalClasses: 'icon',
         },
         label: 'openLists',
+        enabled$: of(this.editionConfig.showLists),
         callback: () => this.openGlobalDialogLists(),
       },
       {
@@ -78,6 +80,7 @@ export class MainMenuComponent implements OnInit, OnDestroy {
           additionalClasses: 'icon',
         },
         label: 'bookmark',
+        enabled$: of(true),
         callback: () => this.generateBookmark(),
       },
       {
@@ -87,6 +90,7 @@ export class MainMenuComponent implements OnInit, OnDestroy {
           additionalClasses: 'icon',
         },
         label: 'downloadXML',
+        enabled$: of(true),
         callback: () => this.downloadXML(),
       },
     ];
@@ -205,5 +209,6 @@ export interface MainMenuItem {
   id: string;
   iconInfo: EvtIconInfo;
   label: string;
+  enabled$: Observable<boolean>;
   callback: () => void;
 }

--- a/src/app/main-menu/main-menu.component.ts
+++ b/src/app/main-menu/main-menu.component.ts
@@ -2,9 +2,13 @@
 import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
 import { AppConfig } from '../app.config';
 import { GlobalListsComponent } from '../components/global-lists/global-lists.component';
 import { EvtInfoComponent } from '../evt-info/evt-info.component';
+import { EVTModelService } from '../services/evt-model.service';
 import { ColorTheme, ThemesService } from '../services/themes.service';
 import { ShortcutsComponent } from '../shortcuts/shortcuts.component';
 import { EvtIconInfo } from '../ui-components/icon/icon.component';
@@ -31,6 +35,7 @@ export class MainMenuComponent implements OnInit, OnDestroy {
     public themes: ThemesService,
     public translate: TranslateService,
     private modalService: ModalService,
+    private evtModelService: EVTModelService,
   ) {
   }
 
@@ -70,7 +75,9 @@ export class MainMenuComponent implements OnInit, OnDestroy {
           additionalClasses: 'icon',
         },
         label: 'openLists',
-        enabled$: of(this.editionConfig.showLists),
+        enabled$: this.evtModelService.namedEntities$.pipe(
+          map(ne => this.editionConfig.showLists && ne.all.entities.length > 0),
+        ),
         callback: () => this.openGlobalDialogLists(),
       },
       {

--- a/src/assets/config/edition_config.json
+++ b/src/assets/config/edition_config.json
@@ -2,6 +2,7 @@
 	"editionTitle": "My Digital Edition",
 	"badge": "alpha",
 	"editionHome": "evt.labcd.unipi.it/",
+	"showLists": true,
 	"availableEditionLevels": [{
 		"id": "diplomatic",
 		"label": "diplomatic"


### PR DESCRIPTION
Add configuration param `showLists` to deactivate lists button from main menu even if there named entities lists encoded in the source file. In this case the detail of entity will be shown only in the reference in the main text.

Handled situation when no named entities lists are found in the source file. In this case both the list button in main menu and detail of the reference in the main text are turned off.