### PR TITLE
Fix missing space in verses display in dipl transcription

### DIFF
--- a/src/app/components/lb/lb.component.html
+++ b/src/app/components/lb/lb.component.html
@@ -1,6 +1,9 @@
 <span class="lb" 
     [evtHtmlAttributes]="data?.attributes"
     [attr.id]="data.id" [attr.data-rend]="data.rend || ''" [attr.data-facs]="data.facs || ''">
-    <br *ngIf="displayBlock$ | async"/>
-    <span class="lineN" *ngIf="data.n && (displayBlock$ | async)">{{data.n}}</span>
+    <ng-container *ngIf="data">
+        <br *ngIf="displayBlock$ | async"/>
+        <span class="lineN" *ngIf="data.n && (displayBlock$ | async)">{{data.n}}</span>
+    </ng-container>
+    <ng-container *ngIf="displayInline$ | async">&nbsp;</ng-container>
 </span>

--- a/src/app/components/lb/lb.component.ts
+++ b/src/app/components/lb/lb.component.ts
@@ -40,6 +40,12 @@ export class LbComponent {
     );
   }
 
+  get displayInline$() {
+    return this.displayBlock$.pipe(
+      map((displayBlock) => !displayBlock),
+    );
+  }
+
   constructor(
     private evtModelService: EVTModelService,
   ) {


### PR DESCRIPTION
The words at the end of the line that do not coincide with the end of a line were attached to those of the next line. Now a space has been added.