### PR TITLE
Fix for editorial conventions 

### DIFF
--- a/src/app/services/editorial-conventions.service.ts
+++ b/src/app/services/editorial-conventions.service.ts
@@ -136,15 +136,9 @@ export class EditorialConventionsService {
         Object.keys(c.attributes)).every((k) => attributes[k] === c.attributes[k])))?.layouts ?? undefined;
 
     if (externalLayouts) {
-      Object.keys(externalLayouts).forEach((editionLevel) => {
-        layouts = {
-          ...defaultKeys || {},
-          [editionLevel]: {
-            ...defaultKeys ? defaultKeys[editionLevel] : {},
-            ...externalLayouts[editionLevel],
-          },
-        };
-      });
+      layouts = {
+        ...externalLayouts || {},
+      }
     }
 
     return layouts;


### PR DESCRIPTION
EVT is only loading the last rule of each item because getLayouts() overwrites the object at every cycle with the default values from editorial-conventions.service.ts.

Below the json used for the test. It's taken from the readme with minimum editing.
For example without this fix, the first group of rules stored in "diplomatic" for element 'add' are ignored and the default rules hardcoded applied instead.

```
{
    "additions": {
        "markup": {
            "element": "add"
        },
        "layouts": {
            "diplomatic": {
                "style": {
                    "background-color": "red"
                }
            },
            "interpretative": {
                "pre": "\\",
                "post": "/",
                "style": {
                    "background-color": "blue"
                }
            }
        }
    },
    "deletions": {
        "markup": {
            "element": "del"
        },
        "layouts": {
            "interpretative": {
                "style": {
                   "background-color": "green"
                }
            }
        }
    }
}
```

FIX:

Since default keys are already placed in the output layout at its initialization
`let layouts: Partial<EditorialConventionLayouts> = defaultKeys;`
there's no need to load them again at every cycle and we can simply spread the new properties from external layout.

