### PR TITLE
Bugfix/no recompiling for custom css

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -181,6 +181,7 @@ export interface EditionConfig {
     }>;
     startingFromDefinitiveLayer: boolean;
     defaultImageZoomLevel: number;
+    maxImageZoomLevel: number;
     showSubstitutionMarker: boolean;
     multiPageEngineForCriticalEdition: boolean;
 }

--- a/src/app/components/osd/osd.component.ts
+++ b/src/app/components/osd/osd.component.ts
@@ -168,7 +168,7 @@ export class OsdComponent implements AfterViewInit, OnDestroy {
     const commonOptions = {
       visibilityRatio: 0.66,
       minZoomLevel: 0.3,
-      maxZoomLevel: 1,
+      maxZoomLevel:  AppConfig.evtSettings.edition.maxImageZoomLevel,
       defaultZoomLevel: AppConfig.evtSettings.edition.defaultImageZoomLevel,
       sequenceMode: true,
       prefixUrl: 'assets/osd/images/',

--- a/src/assets/config/edition_config.json
+++ b/src/assets/config/edition_config.json
@@ -170,5 +170,6 @@
     }
   },
   "defaultImageZoomLevel": 0.8,
+  "maxImageZoomLevel": 2,
   "multiPageEngineForCriticalEdition": false
 }

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
   <base href="./">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="stylesheet" href="assets/config/custom-styles.css">
 </head>
 <body>
   <evt-root></evt-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,7 +4,6 @@
 @import "./assets/scss/themes";
 @import "./assets/scss/mixins";
 @import "./assets/scss/bootstrapOverrides";
-@import "./assets/config/custom-styles.css";
 
 @font-face {
   font-family: "Junicode";


### PR DESCRIPTION
- Move custom style css to static sources in order to avoid the need of compilating them
- Set max zoom level value for images in config