### PR TITLE
Resolve issue 228

### DIFF
--- a/src/app/services/edition-data.service.ts
+++ b/src/app/services/edition-data.service.ts
@@ -6,6 +6,7 @@ import { AppConfig, EditionUrl } from '../app.config';
 import { parseXml } from '../utils/xml-utils';
 import { PrefatoryMatterParserService } from './xml-parsers/prefatory-matter-parser.service';
 import { EditionInfo, EditionSource } from './named-entities.service';
+import { v4 as uuidv4 } from 'uuid';
 
 @Injectable({
   providedIn: 'root',
@@ -50,6 +51,21 @@ export class EditionDataService {
   private loadAndParseEditionData({value, friendlyName}: EditionUrl): Observable<EditionSource> {
     return this.http.get(value, { responseType: 'text' }).pipe(
       map((source) => parseXml(source)),
+      tap(source => {
+        setId(source.lastElementChild as HTMLElement);
+        console.log('edited source', source);
+
+        function setId(element: HTMLElement) {
+          if (element.setAttributeNS) {
+            if (element.getAttribute('xml:id') === null) {
+              element.setAttributeNS("http://www.w3.org/XML/1998/namespace", 'xml:id', `evt-${uuidv4()}`);
+            }
+            for (const child of Array.from(element.children)) {
+              setId(child as HTMLElement);
+            }
+          }
+        }
+      }),
       mergeMap((editionData) => this.loadXIinclude(editionData, value.substring(0, value.lastIndexOf('/') + 1))),
       map(editionData => {
         const editionInfo: EditionInfo = {

--- a/src/assets/config/custom-styles.css
+++ b/src/assets/config/custom-styles.css
@@ -1,7 +1,3 @@
-.w .lb {
-    display: none;
-}
-
 .ab[rend="align-center"] {
     display: block;
     text-align: center;

--- a/src/assets/config/file_config_DOTR.json
+++ b/src/assets/config/file_config_DOTR.json
@@ -1,6 +1,10 @@
 {
 	"editionUrls": [
-		"assets/data/VB-DOTR.xml"
+		{
+			"type": "main",
+			"value":"assets/data/custom/DOTR/VB-complete-xinclude.xml",
+			"enable": true
+		}
 	],
 	"editionImagesSource": {
 		"manifest": {

--- a/src/assets/config/file_config_Pelavicino.json
+++ b/src/assets/config/file_config_Pelavicino.json
@@ -1,6 +1,10 @@
 {
 	"editionUrls": [
-		"assets/data/pelavicino.xml"
+		{
+			"type": "main",
+			"value": "assets/data/pelavicino.xml",
+			"enable": true
+		}
 	],
 	"editionImagesSource": {
 		"manifest": {

--- a/src/assets/config/file_config_PseudoEdition.json
+++ b/src/assets/config/file_config_PseudoEdition.json
@@ -1,6 +1,10 @@
 {
 	"editionUrls": [
-		"assets/data/pseudoEdition.xml"
+		{
+			"type": "main",
+			"value": "assets/data/pseudoEdition.xml",
+			"enable": true
+		}
 	],
 	"editionImagesSource": {
 		"manifest": {

--- a/src/assets/config/file_config_Saba.json
+++ b/src/assets/config/file_config_Saba.json
@@ -1,6 +1,11 @@
 {
 	"editionUrls": [
-		"assets/data/saba.xml"
+		{
+			"type": "main",
+			"value": "assets/data/saba.xml",
+			"enable": true
+		}
+		
 	],
 	"editionImagesSource": {
 		"manifest": {


### PR DESCRIPTION
In this PR we add a method during the parsing phase that assigns an xml:id to each element that lacks one.  These ids are runtime-generated guides and thus are always different each time the site is started but are consistent throughout the browsing session. This allows from any element parsed in Angular to be able to access the original element in the XML document.